### PR TITLE
fix PHP 8 undefined array key warning

### DIFF
--- a/handy.theme
+++ b/handy.theme
@@ -172,7 +172,7 @@ function handy_preprocess_page(&$variables)
     }
     if ($node->hasField('field_extra_class')) {
       $extra_class = $node->get('field_extra_class')->getValue();
-      if($extra_class[0]['value']) {
+      if(isset($extra_class) && $extra_class[0]['value']) {
         $variables['extra_class'] = $extra_class[0]['value'];
       }
     }


### PR DESCRIPTION
Hi Jill,

I'm seeing these warnings in my logs every few minutes:
```
Warning: Undefined array key 0 in handy_preprocess_page() (line 175 of /var/www/mahahome.org/web/themes/contrib/handy/handy.theme) 
Warning: Trying to access array offset on null in handy_preprocess_page() (line 175 of /var/www/mahahome.org/web/themes/contrib/handy/handy.theme) 
```

I think you know I'm taking over most of the Nubay clients, who are all(?) running the Handy theme.

If you don't have intentions of ongoing maintenance for the theme, no worries - just let me know and I'll maintain a fork.  But if you are, I'll submit fixes like this as I see them.